### PR TITLE
fix preprocess.py and fix_bss.py to handle continuation lines in pragma increment_block_number

### DIFF
--- a/src/boot/idle.c
+++ b/src/boot/idle.c
@@ -1,9 +1,7 @@
 #include "global.h"
 #include "terminal.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64"
-// clang-format on
 
 OSThread sMainThread;
 STACK(sMainStack, 0x900);

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -44,7 +44,9 @@
 #include "terminal.h"
 #include "alloca.h"
 
-#pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-eu-mq-dbg:0 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64"
+#pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-eu-mq-dbg:0" \
+                               "gc-jp:64 gc-jp-ce:64 gc-jp-mq:64"    \
+                               "gc-us:64 gc-us-mq:64"
 
 void FaultDrawer_Init(void);
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled);

--- a/src/code/fault.c
+++ b/src/code/fault.c
@@ -44,9 +44,7 @@
 #include "terminal.h"
 #include "alloca.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-eu-mq-dbg:0 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64"
-// clang-format on
 
 void FaultDrawer_Init(void);
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled);

--- a/src/code/main.c
+++ b/src/code/main.c
@@ -7,9 +7,7 @@ s32 gScreenWidth = SCREEN_WIDTH;
 s32 gScreenHeight = SCREEN_HEIGHT;
 u32 gSystemHeapSize = 0;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 PreNmiBuff* gAppNmiBufferPtr;
 Scheduler gScheduler;

--- a/src/code/sys_math3d.c
+++ b/src/code/sys_math3d.c
@@ -5,9 +5,7 @@
 #include "macros.h"
 #include "sys_math3d.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:108 gc-eu-mq:108 gc-jp:108 gc-jp-ce:108 gc-jp-mq:108 gc-us:108 gc-us-mq:108"
-// clang-format on
 
 s32 Math3D_LineVsLineClosestTwoPoints(Vec3f* lineAPointA, Vec3f* lineAPointB, Vec3f* lineBPointA, Vec3f* lineBPointB,
                                       Vec3f* lineAClosestToB, Vec3f* lineBClosestToA);

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -8,9 +8,7 @@
 #include "assets/objects/gameplay_dangeon_keep/gameplay_dangeon_keep.h"
 #include "assets/objects/object_bdoor/object_bdoor.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 static CollisionPoly* sCurCeilingPoly;
 static s32 sCurCeilingBgId;
@@ -1907,9 +1905,7 @@ s32 func_8002F9EC(PlayState* play, Actor* actor, CollisionPoly* poly, s32 bgId, 
     return false;
 }
 
-// clang-format off
 #pragma increment_block_number "gc-eu:22 gc-eu-mq:22 gc-jp:22 gc-jp-ce:22 gc-jp-mq:22 gc-us:22 gc-us-mq:22"
-// clang-format on
 
 // Local data used for Farore's Wind light (stored in BSS)
 LightInfo D_8015BC00;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -4,9 +4,7 @@
 #include "terminal.h"
 #include "overlays/actors/ovl_En_Horse/z_en_horse.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 s16 Camera_RequestSettingImpl(Camera* camera, s16 requestedSetting, s16 flags);
 s32 Camera_RequestModeImpl(Camera* camera, s16 requestedMode, u8 forceModeChange);
@@ -3632,9 +3630,7 @@ s32 Camera_KeepOn3(Camera* camera) {
     return 1;
 }
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 s32 Camera_KeepOn4(Camera* camera) {
     static Vec3f D_8015BD50;

--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -12,9 +12,7 @@ typedef s32 (*ColChkLineFunc)(PlayState*, CollisionCheckContext*, Collider*, Vec
 
 #define SAC_ENABLE (1 << 0)
 
-// clang-format off
 #pragma increment_block_number "gc-eu:64 gc-eu-mq:64 gc-jp:64 gc-jp-ce:64 gc-jp-mq:64 gc-us:64 gc-us-mq:64"
-// clang-format on
 
 #if OOT_DEBUG
 /**
@@ -2695,9 +2693,7 @@ typedef enum {
     /* 2 */ MASSTYPE_NORMAL
 } ColChkMassType;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:252 gc-eu-mq:252 gc-jp:252 gc-jp-ce:252 gc-jp-mq:252 gc-us:252 gc-us-mq:252"
-// clang-format on
 
 /**
  * Get mass type. Immovable colliders cannot be pushed, while heavy colliders can only be pushed by heavy and immovable

--- a/src/code/z_common_data.c
+++ b/src/code/z_common_data.c
@@ -1,9 +1,7 @@
 #include "global.h"
 #include "region.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 ALIGNED(16) SaveContext gSaveContext;
 u32 D_8015FA88;

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -120,9 +120,7 @@ u16 gCamAtSplinePointsAppliedFrame;
 u16 gCamEyePointAppliedFrame;
 u16 gCamAtPointAppliedFrame;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 // Cam ID to return to when a scripted cutscene is finished
 s16 sReturnToCamId;

--- a/src/code/z_kaleido_scope_call.c
+++ b/src/code/z_kaleido_scope_call.c
@@ -1,9 +1,7 @@
 #include "global.h"
 #include "terminal.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 void (*sKaleidoScopeUpdateFunc)(PlayState* play);
 void (*sKaleidoScopeDrawFunc)(PlayState* play);

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -7,9 +7,7 @@
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "assets/objects/gameplay_field_keep/gameplay_field_keep.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 typedef enum {
     /* 0x00 */ LIGHTNING_BOLT_START,
@@ -214,9 +212,7 @@ s16 sLightningFlashAlpha;
 s16 sSunDepthTestX;
 s16 sSunDepthTestY;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 LightNode* sNGameOverLightNode;
 LightInfo sNGameOverLightInfo;

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -100,25 +100,19 @@ static ColliderCylinderInit sLightBallCylinderInit = {
 static u8 D_808E4C58[] = { 0, 12, 10, 12, 14, 16, 12, 14, 16, 12, 14, 16, 12, 14, 16, 10, 16, 14 };
 static Vec3f sZeroVec = { 0.0f, 0.0f, 0.0f };
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 static EnGanonMant* sCape;
 
 // TODO: There's probably a way to match BSS ordering with less padding by spreading the variables out and moving
 // data around. It would be easier if we had more options for controlling BSS ordering in debug.
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 static s32 sSeed1;
 static s32 sSeed2;
 static s32 sSeed3;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192"
-// clang-format on
 
 static BossGanon* sGanondorf;
 

--- a/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
+++ b/src/overlays/actors/ovl_En_Wonder_Item/z_en_wonder_item.c
@@ -53,9 +53,7 @@ ActorProfile En_Wonder_Item_Profile = {
     /**/ NULL,
 };
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 static Vec3f sTagPointsFree[9];
 static Vec3f sTagPointsOrdered[9];

--- a/src/overlays/actors/ovl_En_Xc/z_en_xc.c
+++ b/src/overlays/actors/ovl_En_Xc/z_en_xc.c
@@ -14,9 +14,7 @@
 #include "assets/scenes/dungeons/ice_doukutu/ice_doukutu_scene.h"
 #include "terminal.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 #define FLAGS ACTOR_FLAG_4
 
@@ -1397,9 +1395,7 @@ void func_80B3F3D8(void) {
     Sfx_PlaySfxCentered2(NA_SE_PL_SKIP);
 }
 
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 void EnXc_PlayDiveSFX(Vec3f* src, PlayState* play) {
     static Vec3f D_80B42DA0;

--- a/src/overlays/actors/ovl_Fishing/z_fishing.c
+++ b/src/overlays/actors/ovl_Fishing/z_fishing.c
@@ -11,9 +11,7 @@
 #include "ichain.h"
 #include "terminal.h"
 
-// clang-format off
 #pragma increment_block_number "gc-eu:205 gc-eu-mq:205 gc-jp:207 gc-jp-ce:207 gc-jp-mq:207 gc-us:207 gc-us-mq:207"
-// clang-format on
 
 #define FLAGS ACTOR_FLAG_4
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -354,25 +354,19 @@ void Player_Action_CsAction(Player* this, PlayState* play);
 
 // .bss part 1
 
-// clang-format off
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:0 gc-jp-ce:0 gc-jp-mq:0 gc-us:0 gc-us-mq:0"
-// clang-format on
 
 static s32 D_80858AA0;
 
 // TODO: There's probably a way to match BSS ordering with less padding by spreading the variables out and moving
 // data around. It would be easier if we had more options for controlling BSS ordering in debug.
-// clang-format off
 #pragma increment_block_number "gc-eu:128 gc-eu-mq:128 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128"
-// clang-format on
 
 static s32 D_80858AA4;
 static Vec3f sInteractWallCheckResult;
 static Input* sControlInput;
 
-// clang-format off
 #pragma increment_block_number "gc-eu:192 gc-eu-mq:192 gc-jp:192 gc-jp-ce:192 gc-jp-mq:192 gc-us:192 gc-us-mq:192"
-// clang-format on
 
 // .data
 

--- a/tools/preprocess.py
+++ b/tools/preprocess.py
@@ -11,10 +11,11 @@
 
 import argparse
 from pathlib import Path
-import os
+import re
 import tempfile
 import subprocess
 import sys
+import typing
 
 
 def fail(message):
@@ -22,36 +23,59 @@ def fail(message):
     sys.exit(1)
 
 
-def process_file(version, filename, input, output):
+def process_file(
+    version: str,
+    filename: str,
+    input: typing.TextIO,
+    output: typing.TextIO,
+):
     output.write(f'#line 1 "{filename}"\n')
+    # whether the current line follows a #pragma increment_block_number,
+    # including continuation lines (lines after a \-ending line)
+    in_pragma_incblocknum = False
+    # the line where the #pragma increment_block_number is
+    pragma_incblocknum_first_line_num = None
+    # all the lines from the #pragma increment_block_number line to the last
+    # continuation line, as a list[str]
+    pragma_incblocknum_lines = None
     for i, line in enumerate(input, start=1):
-        if line.startswith("#pragma increment_block_number"):
-            # Grab pragma argument (if any) and remove quotes
-            arg = line.strip()[len("#pragma increment_block_number ") + 1 : -1]
-            amount = 0
-            for part in arg.split():
-                kv = part.split(":")
-                if len(kv) != 2:
-                    fail(
-                        f"{filename}:{i}: increment_block_number must be followed by a list of version:amount pairs"
-                    )
-                if kv[0] != version:
-                    continue
-                try:
-                    amount = int(kv[1])
-                except ValueError:
-                    fail(
-                        f"{filename}:{i}: increment_block_number amount must be an integer"
-                    )
+        if not in_pragma_incblocknum and line.startswith(
+            "#pragma increment_block_number "
+        ):
+            in_pragma_incblocknum = True
+            pragma_incblocknum_first_line_num = i
+            pragma_incblocknum_lines = []
 
-            # Always generate at least one struct so that fix_bss.py can know where the increment_block_number pragmas are
-            if amount == 0:
-                amount = 256
+        if in_pragma_incblocknum:
+            if line.endswith("\\\n"):
+                pragma_incblocknum_lines.append(line)
+            else:
+                in_pragma_incblocknum = False
+                pragma_incblocknum_lines.append(line)
+                amount = 0
+                for s in pragma_incblocknum_lines:
+                    # Note if we had two versions like "abc-def-version" and "def-version"
+                    # then this code would find either given "def-version", but
+                    # thankfully we don't have such nested version names.
+                    m = re.search(rf"{version}:(\d+)\b", s)
+                    if m:
+                        amount = int(m.group(1))
+                        break
 
-            # Write fake structs for BSS ordering
-            for j in range(amount):
-                output.write(f"struct increment_block_number_{i:05}_{j:03};\n")
-            output.write(f'#line {i + 1} "{filename}"\n')
+                # Always generate at least one struct,
+                # so that fix_bss.py can know where the increment_block_number pragmas are
+                if amount == 0:
+                    amount = 256
+
+                # Write fake structs for BSS ordering
+                # pragma_incblocknum_first_line_num is used for symbol uniqueness, and
+                # also by fix_bss.py to locate the pragma these symbols originate from.
+                for j in range(amount):
+                    output.write(
+                        "struct increment_block_number_"
+                        f"{pragma_incblocknum_first_line_num:05}_{j:03};\n"
+                    )
+                output.write(f'#line {i + 1} "{filename}"\n')
         else:
             output.write(line)
 


### PR DESCRIPTION
I went for simple rather than perfect

perfect would be writing a lexer/tokenizer/etc, a lot of code

I just use regex to find / replace `{version}:{amount}`, there could be other garbage in the string (or the arguments not even being strings) and the script wouldn't know. I think this is fine though, at least it's simple

I can do perfect but it'll be a lot more of ugly code